### PR TITLE
Fix 2 runtime errors; issue of failed training accuracy

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ import torch.nn.functional as F
 import torch.optim as optim
 import math
 import pdb
-from DGCNN_embedding import DGCNN 
+from DGCNN_embedding import DGCNN
 from mlp_dropout import MLPClassifier
 
 sys.path.append('%s/pytorch_structure2vec-master/s2v_lib' % os.path.dirname(os.path.realpath(__file__)))
@@ -33,15 +33,15 @@ class Classifier(nn.Module):
             sys.exit()
 
         if cmd_args.gm == 'DGCNN':
-            self.s2v = model(latent_dim=cmd_args.latent_dim, 
+            self.s2v = model(latent_dim=cmd_args.latent_dim,
                             output_dim=cmd_args.out_dim,
-                            num_node_feats=cmd_args.feat_dim+cmd_args.attr_dim, 
+                            num_node_feats=cmd_args.feat_dim+cmd_args.attr_dim,
                             num_edge_feats=0,
                             k=cmd_args.sortpooling_k)
         else:
-            self.s2v = model(latent_dim=cmd_args.latent_dim, 
+            self.s2v = model(latent_dim=cmd_args.latent_dim,
                             output_dim=cmd_args.out_dim,
-                            num_node_feats=cmd_args.feat_dim, 
+                            num_node_feats=cmd_args.feat_dim,
                             num_edge_feats=0,
                             max_lv=cmd_args.max_lv)
         out_dim = cmd_args.out_dim
@@ -76,7 +76,7 @@ class Classifier(nn.Module):
             if node_feat_flag == True:
                 tmp = torch.from_numpy(batch_graph[i].node_features).type('torch.FloatTensor')
                 concat_feat.append(tmp)
-        
+
         if node_tag_flag == True:
             concat_tag = torch.LongTensor(concat_tag).view(-1, 1)
             node_tag = torch.zeros(n_nodes, cmd_args.feat_dim)
@@ -96,15 +96,15 @@ class Classifier(nn.Module):
             node_feat = torch.ones(n_nodes, 1)  # use all-one vector as node features
 
         if cmd_args.mode == 'gpu':
-            node_feat = node_feat.cuda() 
+            node_feat = node_feat.cuda()
             labels = labels.cuda()
 
         return node_feat, labels
 
-    def forward(self, batch_graph): 
+    def forward(self, batch_graph):
         node_feat, labels = self.PrepareFeatureLabel(batch_graph)
         embed = self.s2v(batch_graph, node_feat, None)
-        
+
         return self.mlp(embed, labels)
 
 def loop_dataset(g_list, classifier, sample_idxes, optimizer=None, bsize=cmd_args.batch_size):
@@ -118,13 +118,13 @@ def loop_dataset(g_list, classifier, sample_idxes, optimizer=None, bsize=cmd_arg
 
         batch_graph = [g_list[idx] for idx in selected_idx]
         _, loss, acc = classifier(batch_graph)
-        
+
         if optimizer is not None:
             optimizer.zero_grad()
-            loss.backward()         
+            loss.backward()
             optimizer.step()
 
-        loss = loss.data.cpu().numpy()[0]
+        loss = loss.data.cpu().numpy()
         pbar.set_description('loss: %0.5f acc: %0.5f' % (loss, acc) )
 
         total_loss.append( np.array([loss, acc]) * len(selected_idx))
@@ -153,7 +153,7 @@ if __name__ == '__main__':
     classifier = Classifier()
     if cmd_args.mode == 'gpu':
         classifier = classifier.cuda()
-    
+
     optimizer = optim.Adam(classifier.parameters(), lr=cmd_args.learning_rate)
 
     train_idxes = list(range(len(train_graphs)))
@@ -163,7 +163,7 @@ if __name__ == '__main__':
         classifier.train()
         avg_loss, _ = loop_dataset(train_graphs, classifier, train_idxes, optimizer=optimizer)
         print('\033[92maverage training of epoch %d: loss %.5f acc %.5f\033[0m' % (epoch, avg_loss[0], avg_loss[1]))
-        
+
         classifier.eval()
         test_loss, test_acc = loop_dataset(test_graphs, classifier, list(range(len(test_graphs))))
         print('\033[93maverage test of epoch %d: loss %.5f acc %.5f\033[0m' % (epoch, test_loss[0], test_loss[1]))

--- a/mlp_dropout.py
+++ b/mlp_dropout.py
@@ -29,7 +29,7 @@ class MLPRegression(nn.Module):
         h1 = F.relu(h1)
 
         pred = self.h2_weights(h1)
-        
+
         if y is not None:
             y = Variable(y)
             mse = F.mse_loss(pred, y)


### PR DESCRIPTION
* Use isinstance() instead of type(); type() fails to recognize
    tensor.cuda.TensorFloat when mode=gpu, at least on python 2.7.
* Training loss is not a list, after copied back to cpu.
* **Question to author**: on our GPU server, when I ./run_DGCNN.sh, using default settings shown below, training loss decreased from 0.69 to 0.48, but accuracy is constantly 0.00. Any idea why?

```
====== begin of s2v configuration ======
| msg_average = 0
======   end of s2v configuration ======
Namespace(batch_size=50, data='DD', dropout=True, feat_dim=0, fold=10, gm='DGCNN', hidden=128, latent_dim=[32, 32, 32, 1], learning_rate=1e-05, max_lv=4, mode='gpu', num_class=0, num_epochs=200, out_dim=0, seed=1, sortpooling_k=0.6, test_number=0)
loading data
# classes: 2
# maximum node tag: 82
# train: 1061, # test: 117
k used in SortPooling is: 291
Initializing DGCNN
loss: 0.68376 acc: 0.00000: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████| 21/21 [00:00<00:00, 27.45batch/s]
average training of epoch 0: loss 0.69044 acc 0.00000
loss: 0.68515 acc: 0.00000: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 47.01batch/s]
average test of epoch 0: loss 0.69192 acc 0.00000
loss: 0.70323 acc: 0.00000: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████| 21/21 [00:00<00:00, 27.41batch/s]
average training of epoch 1: loss 0.68251 acc 0.00000
loss: 0.68006 acc: 0.00000: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 46.59batch/s]
average test of epoch 1: loss 0.69230 acc 0.00000
loss: 0.68318 acc: 0.00000: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████| 21/21 [00:00<00:00, 27.63batch/s]
average training of epoch 2: loss 0.67538 acc 0.00000
loss: 0.67748 acc: 0.00000: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 47.12batch/s]
average test of epoch 2: loss 0.69416 acc 0.00000
loss: 0.66298 acc: 0.00000: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████| 21/21 [00:00<00:00, 28.49batch/s]
average training of epoch 3: loss 0.67310 acc 0.00000
loss: 0.67546 acc: 0.00000: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 46.95batch/s]
average test of epoch 3: loss 0.69507 acc 0.00000
loss: 0.62291 acc: 0.00000: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████| 21/21 [00:00<00:00, 27.98batch/s]
average training of epoch 4: loss 0.67112 acc 0.00000
loss: 0.67422 acc: 0.00000: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 47.14batch/s]
average test of epoch 4: loss 0.69502 acc 0.00000
loss: 0.71296 acc: 0.00000: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████| 21/21 [00:00<00:00, 27.61batch/s]
average training of epoch 5: loss 0.67134 acc 0.00000
loss: 0.67313 acc: 0.00000: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 47.05batch/s]
average test of epoch 5: loss 0.69503 acc 0.00000
loss: 0.59624 acc: 0.00000: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████| 21/21 [00:00<00:00, 27.75batch/s]
average training of epoch 6: loss 0.66957 acc 0.00000
......
average training of epoch 196: loss 0.47397 acc 0.00000
loss: 0.65063 acc: 0.00000: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 47.11batch/s]
average test of epoch 196: loss 0.58036 acc 0.00000
loss: 0.42728 acc: 0.00000: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████| 21/21 [00:00<00:00, 30.07batch/s]
average training of epoch 197: loss 0.47682 acc 0.00000
loss: 0.65348 acc: 0.00000: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 47.13batch/s]
average test of epoch 197: loss 0.58178 acc 0.00000
loss: 0.45303 acc: 0.00000: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████| 21/21 [00:00<00:00, 29.32batch/s]
average training of epoch 198: loss 0.48025 acc 0.00000
loss: 0.65295 acc: 0.00000: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 47.14batch/s]
average test of epoch 198: loss 0.57904 acc 0.00000
loss: 0.36955 acc: 0.00000: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████| 21/21 [00:00<00:00, 29.37batch/s]
average training of epoch 199: loss 0.47433 acc 0.00000
loss: 0.65193 acc: 0.00000: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 46.92batch/s]
average test of epoch 199: loss 0.57938 acc 0.00000

```